### PR TITLE
Update TCC to v0.8

### DIFF
--- a/bifrost/btcc.cu
+++ b/bifrost/btcc.cu
@@ -176,7 +176,7 @@ __global__ void reorder_kernel(int          nchan,
             #pragma unroll
             for (pol2=0; pol2<npol; pol2++) {
                 size_t index = ((k*npol+pol1)*npol+pol2)*2;
-                size_t indexu = ((ku*npol+pol2)*npol+pol1)*2;
+                size_t indexu = ((ku*npol+pol1)*npol+pol2)*2;
                 out[indexu + 0] =  in[index + 0];
                 out[indexu + 1] = -in[index + 1];
             }

--- a/bifrost/make_bifrost_plugin.py
+++ b/bifrost/make_bifrost_plugin.py
@@ -70,7 +70,7 @@ define run_ctypesgen
 endef
 
 define run_wrapper
-	python {bifrost_script}/wrap_bifrost_plugin.py $1
+	{python} {bifrost_script}/wrap_bifrost_plugin.py $1
 endef
 
 lib{libname}.so: {libname}.o

--- a/bifrost/make_bifrost_plugin.py
+++ b/bifrost/make_bifrost_plugin.py
@@ -46,8 +46,8 @@ BIFROST_PATH = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 _MAKEFILE_TEMPLATE = """
 {preamble}
 
-CXXFLAGS  += -I{bifrost_include} -I. -I../tensor-core-correlator
-NVCCFLAGS += -I{bifrost_include} -I. -I../tensor-core-correlator -Xcompiler "-fPIC" $(NVCC_GENCODE)
+CXXFLAGS  += -I{bifrost_include} -I. -I../tensor-core-correlator -I../tensor-core-correlator/external/cuda-wrappers/include
+NVCCFLAGS += -I{bifrost_include} -I. -I../tensor-core-correlator -I../tensor-core-correlator/external/cuda-wrappers/include -Xcompiler "-fPIC" $(NVCC_GENCODE)
 LDFLAGS += -L{bifrost_library} -lbifrost -L. -ltcc
 
 PYTHON_BINDINGS_FILE={libname}_generated.py

--- a/bifrost/test/__init__.py
+++ b/bifrost/test/__init__.py
@@ -1,1 +1,0 @@
-import test_btcc


### PR DESCRIPTION
This PR updates the tensor core correlator to version 0.8 (up from 0.5) and enables on-the-fly frequency decimation.