### PR TITLE
Add in on-the-fly channel decimation

### DIFF
--- a/bifrost/Complex.hpp
+++ b/bifrost/Complex.hpp
@@ -1,0 +1,326 @@
+/*
+ * Copyright (c) 2016-2023, The Bifrost Authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in the
+ *   documentation and/or other materials provided with the distribution.
+ * * Neither the name of The Bifrost Authors nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <cuda_fp16.h>
+
+#ifndef __CUDACC_RTC__
+#include <cmath>
+using std::atan2;
+#endif // __CUDACC_RTC__
+
+template<typename Real, class Enable=void>
+struct Complex;
+/*
+template<typename Real, typename PromotedReal=float>
+struct __attribute__((aligned(2*sizeof(Real)))) ComplexBase {
+	typedef Real real_type;
+	union { real_type x, real; };
+	union { real_type y, imag; };
+	ComplexBase(real_type x_, real_type y_=0) : x(x_), y(y_) {}
+	operator Complex<PromotedReal>();
+};
+template<>
+struct __attribute__((aligned(2))) Complex<signed char>
+	: public ComplexBase<signed char> {
+	Complex(signed char x, signed char y=0) : ComplexBase<signed char>(x, y) {}
+};
+template<>
+struct __attribute__((aligned(4))) Complex<short>
+	: public ComplexBase<short> {};
+template<>
+struct __attribute__((aligned(8))) Complex<int>
+	: public ComplexBase<int,double> {};
+*/
+typedef Complex<float>  Complex32;
+typedef Complex<double> Complex64;
+
+template<typename R> inline __host__ __device__ Complex<R> exp(Complex<R> const& a) {
+	return exp(a.x) * Complex<R>(cos(a.y), sin(a.y));
+}
+
+// TODO: Move these somewhere else
+template<typename F>
+inline __host__ __device__
+void quantize(F f, signed char* q) {
+	*q = max(min(rint(f), +127), -127);
+}
+template<typename F>
+inline __host__ __device__
+void quantize(F f, unsigned char* q) {
+	*q = max(min(rint(f), +255), 0);
+}
+template<typename F>
+inline __host__ __device__
+void quantize(F f, signed short* q) {
+	*q = max(min(rint(f), +32767), -32767);
+}
+template<typename F>
+inline __host__ __device__
+void quantize(F f, unsigned short* q) {
+	*q = max(min(rint(f), +65535), 0);
+}
+template<typename F>
+inline __host__ __device__
+void quantize(F f, signed int* q) {
+	*q = max(min(rint(f), +2147483647), -2147483647);
+}
+template<typename F>
+inline __host__ __device__
+void quantize(F f, unsigned int* q) {
+	*q = max(min(rint(f), +4294967295), 0);
+}
+
+template<typename F, typename Q>
+inline __host__ __device__
+void quantize(Complex<F> const& c, Complex<Q>* q) {
+	quantize(c.x, &q->x);
+	quantize(c.y, &q->y);
+}
+
+namespace Complex_detail {
+// TODO: De-dupe this with the one in ArrayIndexer.cuh
+template<bool B, class T = void>
+struct enable_if {};
+template<class T>
+struct enable_if<true, T> { typedef T type; };
+
+template<typename T> struct is_floating_point    { enum { value = false }; };
+template<> struct is_floating_point<float>       { enum { value = true  }; };
+template<> struct is_floating_point<double>      { enum { value = true  }; };
+template<> struct is_floating_point<long double> { enum { value = true  }; };
+
+template<typename T> struct is_storage_type      { enum { value = false }; };
+template<> struct is_storage_type<signed char>   { enum { value = true  }; };
+template<> struct is_storage_type<signed short>  { enum { value = true  }; };
+template<> struct is_storage_type<signed int>    { enum { value = true  }; };
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 9
+// TODO: Complex<half> breaks because there's no half(int) constructor
+template<> struct is_storage_type<__half>          { enum { value = true  }; };
+#endif
+
+#ifdef __CUDACC_VER_MAJOR__
+template<typename Real> struct cuda_vector2_type {};
+template<>              struct cuda_vector2_type<float>  { typedef float2  type; };
+template<>              struct cuda_vector2_type<double> { typedef double2 type; };
+#endif
+
+} // namespace Complex_detail
+
+// Storage-only types
+template<typename T>
+struct __attribute__((aligned(sizeof(T)*2)))
+Complex<T, typename Complex_detail::enable_if<Complex_detail::is_storage_type<T>::value>::type> {
+	typedef T real_type;
+	union { real_type x, real; };
+	union { real_type y, imag; };
+	
+	inline __host__ __device__ Complex() {}
+	inline __host__ __device__ Complex(real_type x_, real_type y_=0) : x(x_), y(y_) {}
+	inline __host__ __device__ Complex& operator+=(Complex c)   { x += c.x; y += c.y; return *this; }
+	inline __host__ __device__ Complex   conj()  const { return Complex(x, -y); }
+};
+
+// Special case for 4+4-bit storage
+struct FourBit {};
+template<>
+struct __attribute__((aligned(1)))
+Complex<FourBit> {
+	typedef signed char real_type;
+	typedef signed char pack_type;
+	pack_type real_imag;
+	
+	inline __host__ __device__ Complex() {}
+	inline __host__ __device__ explicit Complex(real_type x_, real_type y_=0)
+		// Note: Puts the real component into the high 4 bits (big endian)
+		: real_imag((x_ & 0xF) << 4 | (y_ & 0xF)) {}
+	template<typename U>
+	inline __host__ __device__ operator Complex<U>() const {
+		// Note: Assumes the real component is in the high 4 bits (big endian)
+		return Complex<U>(pack_type(real_imag)      >> 4,
+		                  pack_type(real_imag << 4) >> 4);
+	}
+};
+
+// Arithmetic types
+template<typename T>
+struct __attribute__((aligned(sizeof(T)*2)))
+Complex<T, typename Complex_detail::enable_if<Complex_detail::is_floating_point<T>::value>::type> {
+	typedef T real_type;
+	//real_type x, y;
+	union { real_type x, real; };
+	union { real_type y, imag; };
+	
+	inline __host__ __device__ Complex() {}//: x(0), y(0) {}
+	inline __host__ __device__ Complex(real_type x_, real_type y_=0) : x(x_), y(y_) {}
+	// Implicit conversion from low-precision storage types
+	inline __host__ __device__ Complex(Complex<FourBit> c)     : x(((signed char) (c.real_imag & 0xF0))/16), y(((signed char) ((c.real_imag & 0x0F) << 4))/16) {}
+	inline __host__ __device__ Complex(Complex<signed char> c) : x(c.x), y(c.y) {}
+	inline __host__ __device__ Complex(Complex<short> c)       : x(c.x), y(c.y) {}
+	inline __host__ __device__ Complex(Complex<int> c)         : x(c.x), y(c.y) {}
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 9
+	//inline __device__ Complex(Complex<half> c) : x(__half2float(c.x)), y(__half2float(c.y)) {}
+#endif
+#ifdef __CUDACC_VER_MAJOR__
+	// Note: Use float2 to ensure vectorized load/store
+	inline __host__ __device__ Complex(typename Complex_detail::cuda_vector2_type<T>::type c) : x(c.x), y(c.y) {}
+	inline __host__ __device__ operator typename Complex_detail::cuda_vector2_type<T>::type() const { return make_float2(x,y); }
+#endif
+	inline __host__ __device__ Complex& assign(real_type x_, real_type y_) { x = x_; y = y_; return *this; }
+	inline __host__ __device__ Complex& operator+=(Complex c)   { x += c.x; y += c.y; return *this; }
+	inline __host__ __device__ Complex& operator-=(Complex c)   { x -= c.x; y -= c.y; return *this; }
+	inline __host__ __device__ Complex& operator*=(Complex c)   {
+		Complex tmp;
+		tmp.x  = x*c.x;
+		tmp.x -= y*c.y;
+		tmp.y  = y*c.x;
+		tmp.y += x*c.y;
+		return *this = tmp;
+	}
+	inline __host__ __device__ Complex& operator/=(Complex c) {
+		return *this *= c.conj() / c.mag2();
+	}
+	inline __host__ __device__ Complex& operator*=(real_type s) { x *= s; y *= s; return *this; }
+	inline __host__ __device__ Complex& operator/=(real_type s) { return *this *= 1/s; }
+	inline __host__ __device__ Complex  operator+() const { return Complex(+x,+y); }
+	inline __host__ __device__ Complex  operator-() const { return Complex(-x,-y); }
+	inline __host__ __device__ Complex   conj()  const { return Complex(x, -y); }
+	//inline __host__ __device__ real_type real()  const { return x; }
+	//inline __host__ __device__ real_type imag()  const { return y; }
+	//inline __host__ __device__ real_type& real()       { return x; }
+	//inline __host__ __device__ real_type& imag()       { return y; }
+	//inline __host__ __device__ void      real(real_type x_) { x = x_; }
+	//inline __host__ __device__ void      imag(real_type y_) { y = y_; }
+	inline __host__ __device__ real_type phase() const { return atan2(y, x); }
+	inline __host__ __device__ real_type mag2()  const { real_type a = x*x; a += y*y; return a; }
+	inline __host__ __device__ real_type mag()   const { return sqrt(this->mag2()); }
+	inline __host__ __device__ real_type abs()   const { return this->mag(); }
+	inline __host__ __device__ Complex&  mad(Complex a, Complex b) {
+		x += a.x*b.x;
+		x -= a.y*b.y;
+		y += a.y*b.x;
+		y += a.x*b.y;
+		return *this;
+	}
+	//inline __host__ __device__ Complex&  mad(real_type a, Complex b) {
+	//	x += a*b.x;
+	//	y += a*b.y;
+	//	return *this;
+	//}
+	inline __host__ __device__ Complex& msub(Complex a, Complex b) {
+		x -= a.x*b.x;
+		x += a.y*b.y;
+		y -= a.y*b.x;
+		y -= a.x*b.y;
+		return *this;
+	}
+	inline __host__ __device__ bool operator==(Complex const& c) const { return (x==c.x) && (y==c.y); }
+	inline __host__ __device__ bool operator!=(Complex const& c) const { return !(*this == c); }
+	inline __host__ __device__ bool isreal(real_type tol=1e-6) const {
+		return y/x <= tol;
+	}
+};
+
+#define DEFINE_BINARY_OPERATOR(op) \
+template<typename T> \
+inline __host__ __device__ \
+Complex<T> operator op(Complex<T> a, Complex<T> b) { \
+	Complex<T> c = a; \
+	c op##= b; \
+	return c; \
+} \
+template<typename T, typename U> \
+inline __host__ __device__ \
+Complex<T> operator op(Complex<T> a, U b) { \
+	Complex<T> c = a; \
+	c op##= b; \
+	return c; \
+} \
+template<typename T, typename U> \
+inline __host__ __device__ \
+Complex<T> operator op(U a, Complex<T> b) { \
+	Complex<T> c = a; \
+	c op##= b; \
+	return c; \
+}
+DEFINE_BINARY_OPERATOR(+)
+DEFINE_BINARY_OPERATOR(-)
+DEFINE_BINARY_OPERATOR(*)
+DEFINE_BINARY_OPERATOR(/)
+#undef DEFINE_BINARY_OPERATOR
+
+//template<typename Real, typename PromotedReal>
+//ComplexBase<Real,PromotedReal>::operator Complex<PromotedReal>() {
+//	Complex<PromotedReal> c = {real, imag};
+//	return c;
+//}
+
+// HACK TODO: De-dupe this with the one in utils.hpp
+//              (Need to deal with providing it to bfMap)
+namespace detail {
+
+template<typename T, typename U>
+__host__ __device__ inline T type_pun(U x) {
+	static_assert(sizeof(T) == sizeof(U),
+	              "Cannot pun type to different size");
+	union punner_union {
+		T t;
+		U u;
+		__host__ __device__ inline punner_union() {}
+	} punner;
+	punner.u = x;
+	return punner.t;
+}
+
+}
+
+#ifdef __CUDA_ARCH__
+#if defined(__CUDACC_VER_MAJOR__) && __CUDACC_VER_MAJOR__ >= 9
+__device__
+inline Complex<float> __shfl_sync(unsigned mask, Complex<float> const& c,
+                                  int index, int width=warpSize) {
+	typedef unsigned long long shfl_type;
+	return detail::type_pun<Complex<float> >(
+		__shfl_sync(mask, detail::type_pun<shfl_type>(c), index, width));
+}
+#else
+__device__
+inline Complex<float> __shfl(Complex<float> const& c,
+                             int index, int width=warpSize) {
+	typedef unsigned long long shfl_type;
+	return detail::type_pun<Complex<float> >(
+		__shfl(detail::type_pun<shfl_type>(c), index, width));
+}
+#endif
+#endif // __CUDA_ARCH__
+
+__host__ __device__
+inline Complex<float> rintf(Complex<float> const& c) {
+	return Complex<float>(rintf(c.x), rintf(c.y));
+}

--- a/bifrost/btcc.cu
+++ b/bifrost/btcc.cu
@@ -48,6 +48,7 @@
 #include <cuda_fp16.h>
 
 #include "btcc.h"
+#include "Complex.hpp"
 
 #include "libtcc/Correlator.h"
 
@@ -65,74 +66,105 @@ inline BFdtype bf_dtype_from_tcc(int nr_bits) {
     }
 }
 
-template<typename DType>
+struct __attribute__((aligned(1))) nibble2 {
+    // Yikes!  This is dicey since the packing order is implementation dependent!
+    signed char y:4, x:4;
+};
+
+struct __attribute__((aligned(1))) blenib2 {
+    // Yikes!  This is dicey since the packing order is implementation dependent!
+    signed char x:4, y:4;
+};
+
+template<typename IType,typename OType,uint8_t NPol>
 __global__ void swizzel_kernel(int          ntime,
                                int          nchan,
                                int          nstand,
-                               int          npol,
                                int          ntime_per_block,
-                               const DType* in,
-                               DType*       out) {
-    int t, f, s, p;
+                               int          ndecim,
+                               const IType* in,
+                               OType*       out) {
+    int t, f, s, p, d;
     t = blockIdx.x;
     f = blockIdx.y;
     s = threadIdx.x;
+    p = threadIdx.y;
     
     int t0, t1;
     t0 = t / ntime_per_block;
     t1 = t % ntime_per_block;
     
-    int in_idx = t*nchan*nstand*npol + f*nstand*npol + s*npol;
-    int out_idx = f*ntime*nstand*npol + t0*nstand*npol*ntime_per_block \
-                  + s*npol*ntime_per_block;
+    int in_idx = t*nchan*nstand*NPol + ndecim*f*nstand*NPol + s*NPol;
+    int out_idx = f*ntime*nstand*NPol + t0*nstand*NPol*ntime_per_block \
+                  + s*NPol*ntime_per_block;
+    IType temp;
+    OType sum[NPol];
     #pragma unroll
-    for(p=0; p<npol; p++) {
-        out[out_idx + p*ntime_per_block + t1] = in[in_idx + p];
+    for(p=0; p<NPol; p++) {
+        sum[p] = OType(0, 0);
+    }
+    
+    for(d=0; d<ndecim; d++) {
+        #pragma unroll
+        for(p=0; p<NPol; p++) {
+            temp = in[in_idx + p];
+            sum[p] += OType(temp.x, temp.y);
+        }
+        in_idx += nstand*NPol;
+    }
+    
+    #pragma unroll
+    for(p=0; p<NPol; p++) {
+        out[out_idx + p*ntime_per_block + t1] = sum[p];
     }
 }
 
-template<typename DType>
+template<typename IType, typename OType>
 inline void launch_swizzel_kernel(int          ntime,
                                   int          nchan, 
                                   int          nstand, 
                                   int          npol,
                                   int          ntime_per_block,
-                                  DType*       d_in,
-                                  DType*       d_out,
+                                  int          ndecim,
+                                  IType*       d_in,
+                                  OType*       d_out,
                                   cudaStream_t stream=0) {
     dim3 block(nstand, 1);
-    dim3 grid(ntime, nchan, 1);
+    dim3 grid(ntime, nchan/ndecim, 1);
     void* args[] = {&ntime,
                     &nchan,
                     &nstand,
-                    &npol,
                     &ntime_per_block,
+                    &ndecim,
                     &d_in,
                     &d_out};
-    BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)swizzel_kernel<DType>,
-                                             grid, block,
-                                             &args[0], 0, stream),
-                            BF_STATUS_INTERNAL_ERROR);
+    if( npol == 2 ) {
+        BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)swizzel_kernel<IType,OType,2>,
+                                                 grid, block,
+                                                 &args[0], 0, stream),
+                                BF_STATUS_INTERNAL_ERROR);
+    } else {
+         BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)swizzel_kernel<IType,OType,1>,
+                                                 grid, block,
+                                                 &args[0], 0, stream),
+                                BF_STATUS_INTERNAL_ERROR);
+    }
 }
 
-template<typename DType>
+template<typename DType, uint8_t NPol>
 __global__ void accumulate_kernel(int          nchan,
                                   int          nstand,
-                                  int          npolprod,
                                   const DType* in,
                                   DType*       out) {
-    int f, s, p, c;
-    f = blockIdx.x;
-    s = threadIdx.x;
+    int f, b, p;
+    f = blockIdx.y;
+    b = blockIdx.x*blockDim.x + threadIdx.x;
     
-    int b = f*(nstand+1)*(nstand/2) + s*(2*(nstand-1)+1-s)/2 + s;
-    for(int i=b; i<b+nstand-s; i++) {
+    if( b < (nstand+1)*nstand/2 ) {
+        b += f*(nstand+1)*nstand/2;
         #pragma unroll
-        for(p=0; p<npolprod; p++) {
-            #pragma unroll
-            for(c=0; c<2; c++) {
-                out[i*npolprod*2 + p*2 + c] += in[i*npolprod*2 + p*2 + c];
-            }
+        for (p=0; p<NPol*NPol; p++) {
+            out[b*NPol*NPol + p] += in[b*NPol*NPol + p];
         }
     }
 }
@@ -140,30 +172,35 @@ __global__ void accumulate_kernel(int          nchan,
 template<typename DType>
 inline void launch_accumulate_kernel(int          nchan, 
                                      int          nstand, 
-                                     int          npolprod,
+                                     int          npol,
                                      DType*       d_in,
                                      DType*       d_out,
                                      cudaStream_t stream=0) {
-    dim3 block(nstand, 1);
-    dim3 grid(nchan, 1, 1);
+    dim3 block(256, 1);
+    dim3 grid((nstand+1)*nstand/512+1, nchan, 1);
     void* args[] = {&nchan,
                     &nstand,
-                    &npolprod,
                     &d_in,
                     &d_out};
-    BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)accumulate_kernel<DType>,
-                                             grid, block,
-                                             &args[0], 0, stream),
-                            BF_STATUS_INTERNAL_ERROR);
+    if( npol == 2 ) {
+        BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)accumulate_kernel<DType,2>,
+                                                 grid, block,
+                                                 &args[0], 0, stream),
+                                BF_STATUS_INTERNAL_ERROR);
+    } else {
+        BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)accumulate_kernel<DType,1>,
+                                                 grid, block,
+                                                 &args[0], 0, stream),
+                                BF_STATUS_INTERNAL_ERROR);
+    }
 }
 
-template<typename DType>
+template<typename DType, uint8_t NPol>
 __global__ void reorder_kernel(int          nchan,
                                int          nstand,
-                               int          npol,
                                const DType* in,
                                DType*       out) {
-    int f, i, j, pol1, pol2;
+    int f, i, j, p;
     f = blockIdx.x;
     j = threadIdx.x;
 
@@ -171,14 +208,8 @@ __global__ void reorder_kernel(int          nchan,
         int k = f*(nstand+1)*(nstand/2) + j*(j+1)/2 + i;
         int ku = f*(nstand+1)*(nstand/2) + i*(2*(nstand-1)+1-i)/2 + j;
         #pragma unroll
-        for (pol1=0; pol1<npol; pol1++) {
-            #pragma unroll
-            for (pol2=0; pol2<npol; pol2++) {
-                size_t index = ((k*npol+pol1)*npol+pol2)*2;
-                size_t indexu = ((ku*npol+pol1)*npol+pol2)*2;
-                out[indexu + 0] =  in[index + 0];
-                out[indexu + 1] = -in[index + 1];
-            }
+        for (p=0; p<NPol*NPol; p++) {
+            out[ku*NPol*NPol + p] =  in[k*NPol*NPol + p].conj();
         }
     }
 }
@@ -194,24 +225,31 @@ inline void launch_reorder_kernel(int          nchan,
     dim3 grid(nchan, 1, 1);
     void* args[] = {&nchan,
                     &nstand,
-                    &npol,
                     &d_in,
                     &d_out};
-    BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)reorder_kernel<DType>,
-                                             grid, block,
-                                             &args[0], 0, stream),
-                            BF_STATUS_INTERNAL_ERROR);
+    if( npol == 2 ) {
+        BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)reorder_kernel<DType,2>,
+                                                 grid, block,
+                                                 &args[0], 0, stream),
+                                BF_STATUS_INTERNAL_ERROR);
+    } else {
+        BF_CHECK_CUDA_EXCEPTION(cudaLaunchKernel((void*)reorder_kernel<DType,1>,
+                                                 grid, block,
+                                                 &args[0], 0, stream),
+                                BF_STATUS_INTERNAL_ERROR);
+    }
 }
 
 class btcc_impl {
 private:
-    int _nbits;
-    int _ntime;
-    int _nchan;
-    int _nstand;
-    int _npol;
-    int _decim;
-    int _ntime_per_block;
+    int  _nbits;
+    int  _ntime;
+    int  _nchan;
+    int  _nstand;
+    int  _npol;
+    int  _decim;
+    int  _ntime_per_block;
+    bool _is_upconversion;
     
     tcc::Correlator* _tcc;
     void* _reordered = NULL;
@@ -248,6 +286,7 @@ public:
     inline int npol() const { return _npol; }
     inline int decim() const { return _decim; }
     inline int ntime_per_block() const { return _ntime_per_block; }
+    inline bool is_upconversion() const { return _is_upconversion; }
     inline int nbaseline() const { return (_nstand+1)*(_nstand/2); }
     inline BFdtype in_dtype() const { return bf_dtype_from_tcc(_nbits); }
     inline BFdtype out_dtype() const { return _nbits == 16 ? BF_DTYPE_CF32 : BF_DTYPE_CI32; }
@@ -259,17 +298,25 @@ public:
         _npol = npol;
         _decim = decim;
         _ntime_per_block = 128 / _nbits;
+        _is_upconversion = false;
         
         // Sanity checks
         BF_ASSERT_EXCEPTION((_nbits == 4) || (_nbits == 8) || (_nbits == 16), BF_STATUS_UNSUPPORTED_DTYPE);
-        BF_ASSERT_EXCEPTION((_ntime*_decim) % _ntime_per_block == 0, BF_STATUS_UNSUPPORTED_SHAPE);
+        BF_ASSERT_EXCEPTION(_ntime % _ntime_per_block == 0, BF_STATUS_UNSUPPORTED_SHAPE);
         BF_ASSERT_EXCEPTION(_nchan % _decim == 0, BF_STATUS_INVALID_SHAPE);
         
+        // Catch ci4 decimation
+        if( _nbits == 4 && _decim > 1 ) {
+          _nbits = 8;
+          _ntime_per_block = 128 / _nbits;
+          _is_upconversion = true;
+        }
+        
         // Setup the tensor core correlator
-        _tcc = new tcc::Correlator(_nbits, _nstand, _nchan/_decim, _ntime*_decim, _npol);
+        _tcc = new tcc::Correlator(_nbits, _nstand, _nchan/_decim, _ntime, _npol);
         
         // Temporary storage for reordered input data and accumulation
-        cudaMalloc(&_reordered, _ntime*_nchan*_nstand*_npol*_nbits*2);
+        cudaMalloc(&_reordered, _ntime*(_nchan/_decim)*_nstand*_npol*_nbits*2);
         BF_CHECK_CUDA_EXCEPTION(cudaGetLastError(), BF_STATUS_MEM_ALLOC_FAILED);
         cudaMalloc(&_accum, (_nchan/_decim)*(_nstand+1)*(_nstand/2)*_npol*_npol*2*sizeof(float));
         BF_CHECK_CUDA_EXCEPTION(cudaGetLastError(), BF_STATUS_MEM_ALLOC_FAILED);
@@ -285,7 +332,7 @@ public:
     void reset_state() {
         BF_ASSERT_EXCEPTION(_tcc, BF_STATUS_INVALID_STATE); 
         
-        cudaMemset(_accum, 0, (_nchan/_decim)*_nstand*(_nstand+1)/2*_npol*_npol*2*sizeof(float));
+        cudaMemset(_accum, 0, (_nchan/_decim)*_nstand*(_nstand+1)/2*_npol*_npol*sizeof(Complex<float>));
         BF_CHECK_CUDA_EXCEPTION(cudaGetLastError(), BF_STATUS_MEM_OP_FAILED);
     }
     void exec(BFarray const* in, BFarray* out, BFbool dump) {
@@ -296,14 +343,20 @@ public:
         } else {
             cudaStreamBeginCapture(_stream, cudaStreamCaptureModeThreadLocal);
             
-#define LAUNCH_SWIZZEL_KERNEL(DType) \
-            launch_swizzel_kernel(_ntime, _nchan, _nstand, _npol, _ntime_per_block, \
-                                  (DType)in->data, (DType)_reordered, _stream)
+#define LAUNCH_SWIZZEL_KERNEL(IType,OType) \
+            launch_swizzel_kernel(_ntime, _nchan, _nstand, _npol, _ntime_per_block, _decim, \
+                                  (IType)in->data, (OType)_reordered, _stream)
             
             switch( in->dtype ) {
-                case BF_DTYPE_CI4:  LAUNCH_SWIZZEL_KERNEL(signed char*); break;
-                case BF_DTYPE_CI8:  LAUNCH_SWIZZEL_KERNEL(signed short*); break;
-                case BF_DTYPE_CF16: LAUNCH_SWIZZEL_KERNEL(__half*); break;
+                case BF_DTYPE_CI4:
+                    if( in->big_endian ) {
+                        LAUNCH_SWIZZEL_KERNEL(nibble2*,Complex<int8_t>*);
+                    } else {
+                        LAUNCH_SWIZZEL_KERNEL(blenib2*,Complex<int8_t>*);
+                    }
+                    break;
+                case BF_DTYPE_CI8:  LAUNCH_SWIZZEL_KERNEL(char2*,Complex<int8_t>*); break;
+                case BF_DTYPE_CF16: LAUNCH_SWIZZEL_KERNEL(__half2*,Complex<__half>*); break;
                 default: BF_ASSERT_EXCEPTION(false, BF_STATUS_UNSUPPORTED_DTYPE);
             }
             
@@ -313,12 +366,12 @@ public:
             BF_CHECK_CUDA_EXCEPTION(cudaGetLastError(), BF_STATUS_INTERNAL_ERROR);
             
 #define LAUNCH_ACCUMULATE_KERNEL(DType) \
-            launch_accumulate_kernel(_nchan/_decim, _nstand, _npol*_npol, \
+            launch_accumulate_kernel(_nchan/_decim, _nstand, _npol, \
                                      (DType)out->data, (DType)_accum, _stream)
                                   
             switch( out->dtype ) {
-                case BF_DTYPE_CI32: LAUNCH_ACCUMULATE_KERNEL(int*); break;
-                case BF_DTYPE_CF32: LAUNCH_ACCUMULATE_KERNEL(float*); break;
+                case BF_DTYPE_CI32: LAUNCH_ACCUMULATE_KERNEL(Complex<int>*); break;
+                case BF_DTYPE_CF32: LAUNCH_ACCUMULATE_KERNEL(Complex<float>*); break;
                 default: BF_ASSERT_EXCEPTION(false, BF_STATUS_UNSUPPORTED_DTYPE);
             }
             
@@ -336,8 +389,8 @@ public:
                                 (DType)_accum, (DType)out->data, _stream)
           
           switch( out->dtype ) {
-              case BF_DTYPE_CI32: LAUNCH_REORDER_KERNEL(int*); break;
-              case BF_DTYPE_CF32: LAUNCH_REORDER_KERNEL(float*); break;
+              case BF_DTYPE_CI32: LAUNCH_REORDER_KERNEL(Complex<int>*); break;
+              case BF_DTYPE_CF32: LAUNCH_REORDER_KERNEL(Complex<float>*); break;
               default: BF_ASSERT_EXCEPTION(false, BF_STATUS_UNSUPPORTED_DTYPE);
           }
             
@@ -394,7 +447,11 @@ BFstatus BTccExecute(btcc           plan,
     BF_ASSERT(out->shape[0] == plan->nchan()/plan->decim(), BF_STATUS_INVALID_SHAPE);
     BF_ASSERT(out->shape[1] == plan->nbaseline()*plan->npol()*plan->npol(), BF_STATUS_INVALID_SHAPE);
     
-    BF_ASSERT(in->dtype == plan->in_dtype(), BF_STATUS_UNSUPPORTED_DTYPE);
+    if( plan->is_upconversion() ) {
+      BF_ASSERT(in->dtype == BF_DTYPE_CI4, BF_STATUS_UNSUPPORTED_DTYPE);
+    } else {
+      BF_ASSERT(in->dtype == plan->in_dtype(), BF_STATUS_UNSUPPORTED_DTYPE);
+    }
     BF_ASSERT(out->dtype == plan->out_dtype(), BF_STATUS_UNSUPPORTED_DTYPE);
     
     BF_ASSERT(space_accessible_from(in->space, BF_SPACE_CUDA),

--- a/bifrost/btcc.cu
+++ b/bifrost/btcc.cu
@@ -263,6 +263,7 @@ public:
         // Sanity checks
         BF_ASSERT_EXCEPTION((_nbits == 4) || (_nbits == 8) || (_nbits == 16), BF_STATUS_UNSUPPORTED_DTYPE);
         BF_ASSERT_EXCEPTION((_ntime*_decim) % _ntime_per_block == 0, BF_STATUS_UNSUPPORTED_SHAPE);
+        BF_ASSERT_EXCEPTION(_nchan % _decim == 0, BF_STATUS_INVALID_SHAPE);
         
         // Setup the tensor core correlator
         _tcc = new tcc::Correlator(_nbits, _nstand, _nchan/_decim, _ntime*_decim, _npol);

--- a/bifrost/btcc.h
+++ b/bifrost/btcc.h
@@ -1,7 +1,6 @@
 /*
- * Copyright (c) 2021, The Bifrost Authors. All rights reserved.
- # Copyright (c) 2021, The University of New Mexico. All rights reserved.
-
+ * Copyright (c) 2021-2023, The Bifrost Authors. All rights reserved.
+ * Copyright (c) 2021-2023, The University of New Mexico. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +42,8 @@ BFstatus BTccInit(btcc  plan,
                   int   ntime,
                   int   nchan,
                   int   nstand,
-                  int   npol);
+                  int   npol,
+                  int   decim);
 BFstatus BTccSetStream(btcc        plan,
                        void const* stream);
 BFstatus BTccResetState(btcc plan);

--- a/bifrost/btcc.py
+++ b/bifrost/btcc.py
@@ -7,9 +7,9 @@ import btcc_generated as _gen
 class Btcc(BifrostObject):
     def __init__(self):
         BifrostObject.__init__(self, _gen.BTccCreate, _gen.BTccDestroy)
-    def init(self, nbits_c_int, ntime_c_int, nchan_c_int, nstand_c_int, npol_c_int):
+    def init(self, nbits_c_int, ntime_c_int, nchan_c_int, nstand_c_int, npol_c_int, decim_c_int):
         _check(_gen.BTccInit(self.obj, nbits_c_int, ntime_c_int, nchan_c_int,
-                             nstand_c_int, npol_c_int))
+                             nstand_c_int, npol_c_int, decim_c_int))
 
     def execute(self, in_BFarray, out_BFarray, dump_BFbool):
         _check(_gen.BTccExecute(self.obj, asarray(in_BFarray).as_BFarray(),

--- a/bifrost/test/test_btcc.py
+++ b/bifrost/test/test_btcc.py
@@ -1,3 +1,31 @@
+
+# Copyright (c) 2023, The Bifrost Authors. All rights reserved.
+# Copyright (c) 2023, The University of New Mexico. All rights reserved.
+# 
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# * Redistributions of source code must retain the above copyright
+#   notice, this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright
+#   notice, this list of conditions and the following disclaimer in the
+#   documentation and/or other materials provided with the distribution.
+# * Neither the name of The Bifrost Authors nor the names of its
+#   contributors may be used to endorse or promote products derived
+#   from this software without specific prior written permission.
+#   
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 import unittest
 import numpy as np
 import os
@@ -16,7 +44,7 @@ class tcc_tests(unittest.TestCase):
     """A unittest.TestCase collection of unit tests for the btcc module."""
     
     @staticmethod
-    def compute_gold(idata, npol=2):
+    def compute_gold(idata, npol=2, decim=1):
         try:
             _, nchan, nstand, npol = idata.shape
         except ValueError:
@@ -32,6 +60,11 @@ class tcc_tests(unittest.TestCase):
                         for p1 in range(npol):
                             odata[c,npol*npol*k+npol*p0+p1] = (idata[:,c,npol*i+p0]*idata[:,c,npol*j+p1].conj()).sum()
                     k += 1
+                    
+        if decim > 1:
+            odata = odata.reshape(nchan//decim,decim,-1)
+            odata = odata.sum(axis=1)
+            
         return odata
         
     
@@ -54,13 +87,13 @@ class tcc_tests(unittest.TestCase):
         quantize(data, qdata, scale=1.0)
         return qdata.copy(space='cuda')
         
-    def run_test(self, nbit=8, ntime=64, nchan=32, nstand=16, npol=2, naccum=1):
+    def run_test(self, nbit=8, ntime=64, nchan=32, nstand=16, npol=2, decim=1, naccum=1):
         idata = self.create_data(nbit=nbit, ntime=ntime, nchan=nchan, nstand=nstand, npol=npol)
         cc = Btcc()
-        cc.init(nbit, ntime, nchan, nstand, npol)
+        cc.init(nbit, ntime, nchan, nstand, npol, decim)
         
         idata = idata.reshape(ntime,nchan,nstand*npol)
-        odata = bfzeros(shape=(nchan,nstand*(nstand+1)//2*npol*npol), dtype='ci32', space='cuda')
+        odata = bfzeros(shape=(nchan//decim,nstand*(nstand+1)//2*npol*npol), dtype='ci32', space='cuda')
         for i in range(2):
             for j in range(naccum):
                 cc.execute(idata, odata, j == (naccum-1))
@@ -73,20 +106,33 @@ class tcc_tests(unittest.TestCase):
         except ValueError:
             idata = np.int8(idata['re_im'] & 0xF0) + 1j*np.int8((idata['re_im'] & 0x0F) << 4)
             idata /= 16
-        odata_gold = self.compute_gold(idata, npol=npol)
+        odata_gold = self.compute_gold(idata, npol=npol, decim=decim)
         np.testing.assert_equal(odata, odata_gold*naccum)
         
     def test_tcc_ci4(self):
         self.run_test(nbit=4)
         
-    def test_tcc_i4_accum(self):
+    def test_tcc_ci4_decim(self):
+        self.run_test(nbit=4, decim=4)
+        
+    def test_tcc_ci4_accum(self):
         self.run_test(nbit=4, naccum=3)
+        
+    def test_tcc_ci4_decim_accum(self):
+        self.run_test(nbit=4, decim=4, naccum=3)
         
     def test_tcc_ci8(self):
         self.run_test(nbit=8)
         
-    def test_tcc_i8_accum(self):
+    def test_tcc_ci8_decim(self):
+        self.run_test(nbit=8, decim=4)
+        
+    def test_tcc_ci8_accum(self):
         self.run_test(nbit=8, naccum=3)
+        
+    def test_tcc_ci8_decim_accum(self):
+        self.run_test(nbit=8, decim=4, naccum=3)
+        
 
 
 class tcc_test_suite(unittest.TestSuite):

--- a/bifrost/test/test_btcc.py
+++ b/bifrost/test/test_btcc.py
@@ -69,7 +69,6 @@ class tcc_tests(unittest.TestCase):
                     
         return odata
         
-    
     @staticmethod
     def create_data(nbit=8, ntime=64, nchan=32, nstand=16, npol=2):
         data = np.random.rand(ntime,nchan,nstand,npol) \

--- a/bifrost/test/test_btcc.py
+++ b/bifrost/test/test_btcc.py
@@ -51,6 +51,11 @@ class tcc_tests(unittest.TestCase):
             _, nchan, nstandpol = idata.shape
             nstand = nstandpol // npol
             
+        if decim > 1:
+            idata = idata.reshape(-1, nchan//decim, decim, nstand*npol)
+            idata = idata.sum(axis=2)
+            nchan //= decim
+            
         odata = np.zeros((nchan,nstand*(nstand+1)//2*npol*npol), dtype=np.complex64)
         for c in range(nchan):
             k = 0
@@ -61,10 +66,6 @@ class tcc_tests(unittest.TestCase):
                             odata[c,npol*npol*k+npol*p0+p1] = (idata[:,c,npol*i+p0]*idata[:,c,npol*j+p1].conj()).sum()
                     k += 1
                     
-        if decim > 1:
-            odata = odata.reshape(nchan//decim,decim,-1)
-            odata = odata.sum(axis=1)
-            
         return odata
         
     
@@ -81,6 +82,9 @@ class tcc_tests(unittest.TestCase):
             dtype = 'ci8'
         else:
             dtype = 'cf16'
+            
+        if nbit == 8:
+            data /= 16
         
         data = ndarray(data, space='system')
         qdata = ndarray(shape=data.shape, dtype=dtype, space='system')
@@ -119,7 +123,9 @@ class tcc_tests(unittest.TestCase):
         self.run_test(nbit=4, naccum=3)
         
     def test_tcc_ci4_decim_accum(self):
-        self.run_test(nbit=4, decim=4, naccum=3)
+        for nstand in (16, 32, 64):
+            with self.subTest(nstand=nstand):
+                self.run_test(nbit=4, nstand=nstand, decim=4, naccum=3)
         
     def test_tcc_ci8(self):
         self.run_test(nbit=8)
@@ -131,7 +137,9 @@ class tcc_tests(unittest.TestCase):
         self.run_test(nbit=8, naccum=3)
         
     def test_tcc_ci8_decim_accum(self):
-        self.run_test(nbit=8, decim=4, naccum=3)
+        for nstand in (16, 32, 64):
+            with self.subTest(nstand=nstand):
+                self.run_test(nbit=8, nstand=nstand, decim=4, naccum=3)
         
 
 


### PR DESCRIPTION
This PR adds post-cross-correlation channel decimation via a new `decim` keyword.